### PR TITLE
Fix timestamp formatting

### DIFF
--- a/kernelmodule/src/time_stamper.c
+++ b/kernelmodule/src/time_stamper.c
@@ -84,7 +84,7 @@ static ssize_t ts_buffer_readout(struct kobject *kobj, struct kobj_attribute *at
 
     /// fill the requested buffer with the timestamps in the ringbuffer until all is read or a certain limit is reached
     while(r < READ_CHARACTER_LIMIT && ringbuffer.tail != ringbuffer.head){
-        r += sprintf(buf + r, "%lld.%ld\n", ringbuffer.bufferentries[ringbuffer.tail].tv_sec, ringbuffer.bufferentries[ringbuffer.tail].tv_nsec);
+        r += sprintf(buf + r, "%lld.%09ld\n", ringbuffer.bufferentries[ringbuffer.tail].tv_sec, ringbuffer.bufferentries[ringbuffer.tail].tv_nsec);
         ringbuffer.tail = (ringbuffer.tail+1) % N_BUFFER_ENTRIES;
     }
 


### PR DESCRIPTION
This fixes the formatting of the timestamps in the kernel module.

Without this change, leading zeros on the nanoseconds side are not displayed, leading to errors when reading the timestamp as a decimal number.

Before:
1696508620.987270696
1696508620.989755690
1696508620.992240202
1696508620.994725899
1696508620.997212171
1696508620.999697202
1696508621.2182381  
1696508621.4668152  
1696508621.7153757  
1696508621.9639529  
1696508621.12125300 
1696508621.14610738 
1696508621.17095362 
1696508621.19581522 

After:
1696508620.987270696                
1696508620.989755690                
1696508620.992240202                
1696508620.994725899                
1696508620.997212171                
1696508620.999697202                
1696508621.002182381
1696508621.004668152
1696508621.007153757
1696508621.009639529
1696508621.012125300
1696508621.014610738
1696508621.017095362
1696508621.019581522
