### PR TITLE
Use the DRV_NAME in the timestamp buffer path

### DIFF
--- a/kernelmodule/src/time_stamper.c
+++ b/kernelmodule/src/time_stamper.c
@@ -110,7 +110,7 @@ static int __init ts_init(void)
     int err;
 
     /// create sysfs kernel object folder for the file to access in the file system under /sys/kernel/time_stamper/
-    ts_kobject = kobject_create_and_add("time_stamper", kernel_kobj);
+    ts_kobject = kobject_create_and_add(DRV_NAME, kernel_kobj);
     if(!ts_kobject)
         return -ENOMEM;
 


### PR DESCRIPTION
This simplified creating several kernel modules for timestamping a number of signals on different pins.

This does not change the behaviour of the module in any way if DRV_NAME keeps its default value.